### PR TITLE
Add blog post cards to homepage

### DIFF
--- a/src/components/PostCard.astro
+++ b/src/components/PostCard.astro
@@ -1,0 +1,20 @@
+---
+import type { CollectionEntry } from 'astro:content';
+import FormattedDate from './FormattedDate.astro';
+
+interface Props {
+  post: CollectionEntry<'blog'>;
+}
+
+const { post } = Astro.props as Props;
+---
+
+<article class="bg-white dark:bg-slate-700 rounded-lg shadow p-4 my-4 flex flex-col gap-2">
+  <h2 class="text-2xl font-bold">
+    <a href={`/${post.slug}/`} class="hover:underline">{post.data.title}</a>
+  </h2>
+  <p class="text-sm text-gray-600 dark:text-gray-300">
+    <FormattedDate date={post.data.pubDate} />
+  </p>
+  <p>{post.data.description}</p>
+</article>

--- a/src/pages/[...slug].astro
+++ b/src/pages/[...slug].astro
@@ -3,18 +3,17 @@ import { type CollectionEntry, getCollection } from 'astro:content';
 import BlogPost from '../layouts/BlogPost.astro';
 
 export async function getStaticPaths() {
-	const posts = await getCollection('blog');
-	return posts.map((post) => ({
-		params: { slug: post.slug },
-		props: post,
-	}));
+        const posts = await getCollection('blog');
+        return posts.map((post) => ({
+                params: { slug: post.slug },
+                props: post,
+        }));
 }
-type Props = CollectionEntry<'blog'>;
 
-const post = Astro.props;
+const post = Astro.props as CollectionEntry<'blog'>;
 const { Content } = await post.render();
 ---
 
 <BlogPost {...post.data}>
-	<Content />
+        <Content />
 </BlogPost>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -4,9 +4,10 @@ import Header from '../components/Header.astro';
 import Footer from '../components/Footer.astro';
 import { SITE_TITLE, SITE_DESCRIPTION } from '../consts';
 import { getCollection } from 'astro:content';
+import PostCard from '../components/PostCard.astro';
 
 const posts = (await getCollection('blog')).sort(
-	(a, b) => a.data.pubDate.valueOf() - b.data.pubDate.valueOf()
+        (a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf()
 );
 ---
 
@@ -17,12 +18,17 @@ const posts = (await getCollection('blog')).sort(
 	</head>
 	<body>
 		<Header />
-		<main class="">
-			<h1 class="mt-4 font-bold text-5xl">Welcome to Tag, Tweak, Test</h1>
-			<p class="mt-4">
-				All about coding in digital marketing - get tips on using tag managers, tests with dynamic content, and improving site performance. 🚀
-			</p>
-		</main>
+                <main>
+                        <h1 class="mt-4 font-bold text-5xl">Welcome to Tag, Tweak, Test</h1>
+                        <p class="mt-4">
+                                All about coding in digital marketing - get tips on using tag managers, tests with dynamic content, and improving site performance. 🚀
+                        </p>
+                        <div class="mt-8 grid gap-6 md:grid-cols-2">
+                                {posts.map((post) => (
+                                        <PostCard post={post} />
+                                ))}
+                        </div>
+                </main>
 		<Footer />
 	</body>
 </html>


### PR DESCRIPTION
## Summary
- convert `[...slug].astro` into a blog post card component
- show blog post cards on the homepage
- keep individual blog post pages working

## Testing
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_683ffddb7a9883289e4f3d129fb3a59f