### PR TITLE
Add OG image

### DIFF
--- a/public/og-image.svg
+++ b/public/og-image.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#ffb347"/>
+      <stop offset="100%" stop-color="#ffcc33"/>
+    </linearGradient>
+  </defs>
+  <rect width="100%" height="100%" fill="url(#bg)"/>
+  <text x="50%" y="50%" text-anchor="middle" dominant-baseline="central"
+        font-family="Georgia, 'Times New Roman', serif" font-size="120"
+        fill="#ffffff" stroke="#000000" stroke-width="3">
+    Tag Tweak Test
+  </text>
+</svg>

--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -11,7 +11,7 @@ interface Props {
 
 const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 
-const { title, description, image = '/blog-placeholder-1.jpg' } = Astro.props;
+const { title, description, image = '/og-image.svg' } = Astro.props;
 ---
 
 <!-- Global Metadata -->


### PR DESCRIPTION
## Summary
- use a site-specific OG image instead of the placeholder
- create a simple orange banner image for Tag Tweak Test

## Testing
- `npm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_e_68400721d72c8328b555785dfd9ee9fc