### PR TITLE
Add contact form and Cloudflare email worker

### DIFF
--- a/functions/contact.ts
+++ b/functions/contact.ts
@@ -1,0 +1,26 @@
+export const onRequestPost: PagesFunction = async ({ request }) => {
+  const form = await request.formData();
+  const name = String(form.get('name') || '');
+  const email = String(form.get('email') || '');
+  const message = String(form.get('message') || '');
+
+  const body = {
+    personalizations: [{ to: [{ email: 'info@tagtweaktest.com' }] }],
+    from: { email: 'no-reply@tagtweaktest.com' },
+    subject: `Contact form submission from ${name}`,
+    content: [
+      {
+        type: 'text/plain',
+        value: `From: ${name} <${email}>\n\n${message}`,
+      },
+    ],
+  };
+
+  await fetch('https://api.mailchannels.net/tx/v1/send', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+
+  return new Response('Message sent');
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tagtweaktest",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tagtweaktest",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "dependencies": {
         "@astrojs/mdx": "^4.3.0",
         "@astrojs/rss": "^4.0.5",

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -16,7 +16,7 @@ import { SITE_TITLE } from "../consts";
 		</svg> -->
     <h2 class="self-start"><a href="/">{SITE_TITLE}</a></h2>
     <div class="internal-links">
-      <HeaderLink href="/">Contact</HeaderLink>
+      <HeaderLink href="/contact">Contact</HeaderLink>
       <HeaderLink href="/about">About</HeaderLink>
     </div>
   </nav>

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -1,0 +1,34 @@
+---
+import BaseHead from '../components/BaseHead.astro';
+import Header from '../components/Header.astro';
+import Footer from '../components/Footer.astro';
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <BaseHead title="Contact" description="Get in touch with Tag Tweak Test" />
+  </head>
+  <body>
+    <Header />
+    <main>
+      <h1 class="mt-4 font-bold text-4xl">Contact Us</h1>
+      <form action="/api/contact" method="post" class="mt-6 flex flex-col max-w-xl gap-4">
+        <label>
+          <span class="block">Name</span>
+          <input type="text" name="name" required class="border p-2 w-full" />
+        </label>
+        <label>
+          <span class="block">Email</span>
+          <input type="email" name="email" required class="border p-2 w-full" />
+        </label>
+        <label>
+          <span class="block">Message</span>
+          <textarea name="message" required rows="5" class="border p-2 w-full"></textarea>
+        </label>
+        <button type="submit" class="bg-ttt-blue text-white p-2 rounded">Send</button>
+      </form>
+    </main>
+    <Footer />
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add contact page with form posting to worker
- link contact page in navigation
- create `contact` Cloudflare function to send email via MailChannels
- sync `package-lock.json` version

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68400cb27a048328b7d2da3a9f5cfd8b